### PR TITLE
BISERVER-7981 - 404 message for pentaho/mantle/messages/messages_supported_languages.properties

### DIFF
--- a/pentaho-mql-editor/build.properties
+++ b/pentaho-mql-editor/build.properties
@@ -29,3 +29,4 @@ dependency.xstream.revision=1.4.2
 dependency.jettison.revision=1.2
 gwt-module.path=org.pentaho.commons.metadata.mqleditor.MetaDataEditorModule
 package.id=${ivy.artifact.id}-package
+dependency.gwt.revision=2.5.1

--- a/pentaho-mql-editor/ivy.xml
+++ b/pentaho-mql-editor/ivy.xml
@@ -53,12 +53,12 @@
 
         <!--  Testing dependencies -->
         <dependency org="junit" name="junit" rev="4.3.1" transitive="false" conf="test->default"/>
-        <dependency org="com.google.gwt" name="gwt-servlet" rev="2.4.0" conf="default->default"/>
+        <dependency org="com.google.gwt" name="gwt-servlet" rev="${dependency.gwt.revision}" conf="default->default"/>
         <dependency org="pentaho" name="pentaho-platform-core-test" rev="${dependency.pentaho-platform.revision}" changing="true" conf="test->default"/>
       
 	    <!-- it doesn't matter what platform of gwt-dev we use here. GWT compile only cares about the API part of the jar -->
-    	<dependency org="com.google.gwt" name="gwt-dev"  rev="2.4.0" conf="codegen->default"/>        
-    	<dependency org="com.google.gwt" name="gwt-user" rev="2.4.0" conf="codegen->default" />
+    	<dependency org="com.google.gwt" name="gwt-dev"  rev="${dependency.gwt.revision}" conf="codegen->default"/>        
+    	<dependency org="com.google.gwt" name="gwt-user" rev="${dependency.gwt.revision}" conf="codegen->default" />
 
         <dependency org="com.google.gwt" name="gwt-incubator" rev="2.1.0" conf="codegen->default"/>
         <dependency org="com.allen_sauer" name="gwt-dnd" rev="3.1.2" conf="codegen->default"/>


### PR DESCRIPTION
BISERVER-7981 - 404 message for pentaho/mantle/messages/messages_supported_languages.properties

updated the gwt version to 2.5.1 to support the use of GWT.getModuleBaseForStaticFiles and to be consistent with other GWT projects.
