### PR TITLE
[BACKLOG-3830] Update projects from vfs 1 to vfs 2

### DIFF
--- a/pentaho-mql-editor/ivy.xml
+++ b/pentaho-mql-editor/ivy.xml
@@ -25,7 +25,6 @@
         <!--  will not properly pull from ibiblio maven2. needs classifier of 'lgpl'
 -->
         <dependency org="commons-httpclient" name="commons-httpclient" rev="3.0.1" transitive="false"/>
-        <dependency org="commons-vfs" name="commons-vfs" rev="1.0" transitive="false"/>
         <!-- explicit resolve for commons-lang to avoid downstream eviction issues in PRD of all things --> 
         <dependency org="commons-lang" name="commons-lang" rev="2.6" transitive="false"/>
         


### PR DESCRIPTION
VFS is brought in by kettle-engine, no explicit dependency on it.