### PR TITLE
[SP-3002] Conditions set with AND NOT revert to AND on reload of the query browser in Pentaho Metadata (6.1 Suite)

### DIFF
--- a/pentaho-mql-editor/src/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceCWMDelegate.java
+++ b/pentaho-mql-editor/src/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceCWMDelegate.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;
@@ -574,6 +574,8 @@ public class MQLEditorServiceCWMDelegate {
       FormulaParser fp = new FormulaParser( w.getCondition() );
 
       Condition cond = fp.getCondition();
+
+      cond.setCombinationType( CombinationType.getByName( w.getOperator() ) );
 
       String colId = fp.getColID();
 


### PR DESCRIPTION
-backport of #23