### PR TITLE
[SP-6635] Backport of PPP-4895 - Vulnerable Component: Jettison

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <commons-gwt.version>10.2.0.0-SNAPSHOT</commons-gwt.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-xul.version>10.2.0.0-SNAPSHOT</commons-xul.version>
-    <jettison.version>1.2</jettison.version>
     <junit.version>4.3.1</junit.version>
     <pdi.version>10.2.0.0-SNAPSHOT</pdi.version>
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>


### PR DESCRIPTION
- [PPP-4895] Update/Remove jettison version as it's specified in parent pom.

[PPP-4895]: https://hv-eng.atlassian.net/browse/PPP-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ