### PR TITLE
fix: Backport of PRD-6182 - PRD query editor does not correctly parse complex conditions and throws a null pointer exception (10.2 Suite) [SP-6807]

### DIFF
--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/FormulaParser.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/FormulaParser.java
@@ -21,6 +21,8 @@ import java.util.regex.Pattern;
 import org.pentaho.commons.metadata.mqleditor.Operator;
 import org.pentaho.commons.metadata.mqleditor.beans.Condition;
 
+import javax.swing.*;
+
 public class FormulaParser {
 
   private static final String WRAPPED = "([^\\(]*)\\(\\[([^\\]]*)\\];(.*)(?=\\))"; //$NON-NLS-1$
@@ -96,7 +98,19 @@ public class FormulaParser {
       }
     }
 
-    Operator op = Operator.parse( functionName.toUpperCase() );
+    String errorMessage = "";
+    if ( functionName == null) {
+       errorMessage = "Unsupported syntax in query: " + formula;
+    }
+
+    Operator op = null;
+    try {
+      op = Operator.parse( functionName.toUpperCase() );
+    } catch ( Exception e ) {
+      JOptionPane.showMessageDialog(new JFrame(), errorMessage, "Dialog", JOptionPane.ERROR_MESSAGE);
+      throw new RuntimeException( e );
+    }
+
     // handle special NOT() wrapped functions
     if ( notOperator ) {
       switch ( op ) {


### PR DESCRIPTION
[SP-6807]

[SP-6807]: https://hv-eng.atlassian.net/browse/SP-6807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ