### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -45,7 +45,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
         <executions>
           <execution>
             <goals>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -43,9 +43,8 @@
       <artifactId>jettison</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>${gwt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
+        <version>${gwt.version}</version>
         <optional>true</optional>
         <exclusions>
           <exclusion>
@@ -199,17 +200,5 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
-          <version>${gwt.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
 </project>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `pom.xml` files to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, and `gwt-dev` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization.

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.