### PR TITLE
build[SP-6878]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -45,7 +45,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
         <executions>
           <execution>
             <goals>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -43,9 +43,8 @@
       <artifactId>jettison</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>${gwt.version}</version>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
+        <version>${gwt.version}</version>
         <optional>true</optional>
         <exclusions>
           <exclusion>
@@ -199,17 +200,5 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
-          <version>${gwt.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
 </project>


### PR DESCRIPTION
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId (https://github.com/pentaho/mql-editor/pull/85)