### PR TITLE
fix: ensure xml error is shown in GWT implementation [PRD-6183]

### DIFF
--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
@@ -124,7 +124,7 @@ public class MQLEditorServiceGwtImpl implements MQLEditorService {
       }
     }, new AsyncCallback<String>() {
       public void onFailure( Throwable arg0 ) {
-        if ( arg0.getMessage().contains( "Could not parse XML definition" ) ) {
+        if ( arg0 instanceof IllegalArgumentException && arg0.getMessage() != null ) {
           callback.error( arg0.getMessage(), arg0 );
         } else {
           callback.error( "error loading metadata domains: ", arg0 );

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
@@ -124,7 +124,11 @@ public class MQLEditorServiceGwtImpl implements MQLEditorService {
       }
     }, new AsyncCallback<String>() {
       public void onFailure( Throwable arg0 ) {
-        callback.error( "error loading metadata domains: ", arg0 );
+        if ( arg0.getMessage().contains( "Could not parse XML definition" ) ) {
+          callback.error( arg0.getMessage(), arg0 );
+        } else {
+          callback.error( "error loading metadata domains: ", arg0 );
+        }
       }
 
       public void onSuccess( String arg0 ) {

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
@@ -30,7 +30,7 @@ public interface MQLEditorGwtService extends RemoteService {
 
   MqlDomain getDomainByName( String name );
 
-  String saveQuery( MqlQuery model ) throws IllegalStateException;
+  String saveQuery( MqlQuery model ) throws IllegalArgumentException;
 
   String serializeModel( MqlQuery query );
 

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
@@ -30,7 +30,7 @@ public interface MQLEditorGwtService extends RemoteService {
 
   MqlDomain getDomainByName( String name );
 
-  String saveQuery( MqlQuery model );
+  String saveQuery( MqlQuery model ) throws IllegalStateException;
 
   String serializeModel( MqlQuery query );
 


### PR DESCRIPTION
Addresses PRD-6183.

XML error was only being shown when the Preview was done, not when the query was being saved.
Now the error will be shown correctly.
<img width="491" height="322" alt="Screenshot 2026-03-31 at 14 25 03" src="https://github.com/user-attachments/assets/790dc9ec-1919-4c10-8eda-fcc45c7875c0" />
