### PR TITLE
DEVO-14154: license/copyright rebrand

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the 
+Pentaho Developer Edition 11.0 Copyright 2026 Pentaho Canada Inc.; licensed under the 
 Business Source License 1.1 (BSL). This project may include third party components that
 are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
@@ -8,9 +8,9 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
-                      Hitachi Vantara, LLC.
+Licensor:             Pentaho Canada Inc.
+Licensed Work:        Pentaho Developer Edition 11.0. The Licensed Work is (c) 2026
+                      Pentaho Canada Inc.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       Apache 2.0

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/AggType.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/AggType.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/ColumnType.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/ColumnType.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/CombinationType.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/CombinationType.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlBusinessTable.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlBusinessTable.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlCategory.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlCategory.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlColumn.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlColumn.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlCondition.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlCondition.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlDomain.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlDomain.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlModel.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlModel.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlOrder.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlOrder.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlQuery.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/MqlQuery.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/Operator.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/Operator.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Category.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Category.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Column.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Column.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Condition.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Condition.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Domain.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Domain.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Model.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Model.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Order.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Order.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Query.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/beans/Query.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.beans;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/AbstractMqlEditor.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/AbstractMqlEditor.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/MQLEditorService.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/MQLEditorService.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/MqlDialogListener.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/MqlDialogListener.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/OldSwtMqlEditor.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/OldSwtMqlEditor.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/SwingMqlEditor.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/SwingMqlEditor.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/SwtMqlEditor.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/SwtMqlEditor.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/ConditionsController.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/ConditionsController.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.controllers;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/MainController.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/MainController.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.controllers;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/OrderController.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/OrderController.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.controllers;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/PreviewController.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/PreviewController.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.controllers;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/SelectedColumnController.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/controllers/SelectedColumnController.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.controllers;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/GwtMqlEditor.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/GwtMqlEditor.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.gwt;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/MQLEditorServiceGwtImpl.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.gwt;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtService.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.gwt.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtServiceAsync.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/gwt/util/MQLEditorGwtServiceAsync.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.gwt.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/AbstractModelNode.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/AbstractModelNode.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/ConstraintXml.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/ConstraintXml.java
@@ -1,3 +1,14 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
 package org.pentaho.commons.metadata.mqleditor.editor.models;
 
 import jakarta.xml.bind.annotation.XmlAccessType;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/ConstraintsXml.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/ConstraintsXml.java
@@ -1,3 +1,14 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
 package org.pentaho.commons.metadata.mqleditor.editor.models;
 
 import jakarta.xml.bind.annotation.XmlAccessType;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UICategory.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UICategory.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIColumn.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIColumn.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIColumns.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIColumns.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UICondition.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UICondition.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIConditions.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIConditions.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIDomain.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIDomain.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIModel.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIModel.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIOrder.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIOrder.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIOrders.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIOrders.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIQuery.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/UIQuery.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/Workspace.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/models/Workspace.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.models;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/MQLEditorServiceCWMImpl.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/MQLEditorServiceCWMImpl.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/MQLEditorServiceImpl.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/MQLEditorServiceImpl.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/CWMStartup.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/CWMStartup.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/ConditionFormatter.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/ConditionFormatter.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/FormulaParser.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/FormulaParser.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceCWMDelegate.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceCWMDelegate.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceDelegate.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceDelegate.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/OperatorFormatter.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/OperatorFormatter.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/messages/GwtMqlMessages.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/messages/GwtMqlMessages.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.messages;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/messages/IMqlMessages.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/messages/IMqlMessages.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.messages;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/utils/ModelSerializer.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/utils/ModelSerializer.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.utils;

--- a/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/utils/ModelUtil.java
+++ b/impl/src/main/java/org/pentaho/commons/metadata/mqleditor/utils/ModelUtil.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.utils;

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/MetaDataEditorModule.gwt.xml
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/MetaDataEditorModule.gwt.xml
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!--
   This is the generic GWT module from which concreate implementations are based. if you want to add MQL Editing
   functionality to your GWT application, this is the module to inherit.

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/beans/package.html
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/beans/package.html
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
 </head>

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/controllers/package.html
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/controllers/package.html
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
 </head>

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/models/package.html
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/models/package.html
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
 </head>

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/editor.html
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/editor.html
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame-gwt-overlay.xul
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame-gwt-overlay.xul
@@ -1,4 +1,15 @@
 <?xml version="1.0"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <overlay 
   xmlns="http://www.pentaho.org/there.is.only.xul" xmlns:pen="http://www.pentaho.org/2008/xul">
   <!-- Mod size -->

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame-swt-overlay.xul
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame-swt-overlay.xul
@@ -1,4 +1,15 @@
 <?xml version="1.0"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <overlay 
   xmlns="http://www.pentaho.org/there.is.only.xul" xmlns:pen="http://www.pentaho.org/2008/xul">
   <treecol id="combineColumn" type="combobox"/>

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame.xul
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame.xul
@@ -1,4 +1,15 @@
 <?xml version="1.0"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 
 <dialog id="mqlEditorDialog" buttonlabelextra1="${preview}"
   buttonlabelaccept="${ok}" buttonlabelcancel="${cancel}" buttons="extra1,accept,cancel"

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame_supported_languages.properties
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame_supported_languages.properties
@@ -1,8 +1,8 @@
 #
 # *******************************************************************************
-# Hitachi Vantara
+# Pentaho
 #
-# Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+# Copyright (C) 2018 - 2026 by Pentaho : http://www.pentaho.com
 # *******************************************************************************
 #
 

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame_zh_CN.properties
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/editor/xul/mainFrame_zh_CN.properties
@@ -1,8 +1,8 @@
 #
 # *******************************************************************************
-# Hitachi Vantara
+# Pentaho
 #
-# Copyright (C) 2020 by Hitachi Vantara : http://www.pentaho.com
+# Copyright (C) 2020 - 2026 by Pentaho : http://www.pentaho.com
 # *******************************************************************************
 #
 #

--- a/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/package.html
+++ b/impl/src/main/resources/org/pentaho/commons/metadata/mqleditor/package.html
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
 </head>

--- a/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/WorkspaceTest.java
+++ b/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/WorkspaceTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor;

--- a/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceDelegateTest.java
+++ b/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/MQLEditorServiceDelegateTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/OperatorFormatterTest.java
+++ b/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/editor/service/util/OperatorFormatterTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.editor.service.util;

--- a/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/utils/FormulaParserTest.java
+++ b/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/utils/FormulaParserTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.utils;

--- a/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/utils/ModelSerializerTest.java
+++ b/impl/src/test/java/org/pentaho/commons/metadata/mqleditor/utils/ModelSerializerTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.commons.metadata.mqleditor.utils;


### PR DESCRIPTION
Automated license header and brand update (see update-reports/). Generated and locally validated by updater.py, published by publish_branches.py.